### PR TITLE
feat: add pagination limit in config

### DIFF
--- a/lib/sources/stargaze/index.ts
+++ b/lib/sources/stargaze/index.ts
@@ -12,9 +12,11 @@ const PAGINATION_LIMIT = 100;
 
 export default class StargazeNFT extends NFTBase {
   concurrencyLimit: number;
+  paginationLimit: number;
   constructor(rpc: string, logger: Logger<never>, params: any) {
     super(rpc, logger, params);
     this.concurrencyLimit = params.concurrency_limit;
+    this.paginationLimit = params.pagination_limit || PAGINATION_LIMIT;
   }
 
   getAllTokens = async (
@@ -31,12 +33,12 @@ export default class StargazeNFT extends NFTBase {
         {
           all_tokens: {
             start_after,
-            limit: PAGINATION_LIMIT,
+            limit: this.paginationLimit,
           },
         },
       );
       out.push(...data.tokens);
-      if (data.tokens.length < PAGINATION_LIMIT) {
+      if (data.tokens.length < this.paginationLimit) {
         break;
       }
       start_after = data.tokens[data.tokens.length - 1];


### PR DESCRIPTION
```toml
[protocols.badkids]
type = "nft"
source = "stargaze"
rpc = "https://stargaze-rpc.polkachu.com:443/"
jitter = 1000
concurrency_limit = 10
contract = "stars19jq6mj84cnt9p7sagjxqf8hxtczwc8wlpuwe4sh62w45aheseues57n420"
pagination_limit = 30
[protocols.badkids.assets.dATOM]
multiplier = 1.1
[protocols.badkids.assets.dTIA]
multiplier = 1.1

```

```sql
INSERT INTO schedule (protocol_id,asset_id,multiplier,"start","end",enabled) VALUES
	 ('badkids','dATOM',1.1,1740697180,1838001973,1),
	 ('badkids','dTIA',1.1,1740697180,1838001973,1);
```
